### PR TITLE
Refactor it to be a standalone plugin instead of SCM::Git subclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ install_plugin Capistrano::SCM::Git
 ```
 to
 ```ruby
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
+
 require "capistrano/scm/git-with-submodules"
 install_plugin Capistrano::SCM::Git::WithSubmodules
 ```

--- a/lib/capistrano/scm/git-with-submodules.rb
+++ b/lib/capistrano/scm/git-with-submodules.rb
@@ -1,36 +1,40 @@
 require "capistrano/scm/git"
 
-class Capistrano::SCM::Git::WithSubmodules < Capistrano::SCM::Git
-  alias_method :origin_archive_to_release_path, :archive_to_release_path if method_defined?(:archive_to_release_path)
+class Capistrano::SCM::Git::WithSubmodules < Capistrano::Plugin
 
-  def archive_to_release_path
-    origin_archive_to_release_path
-
-    return unless backend.test(:test, '-e', release_path) && backend.test("ls -A #{release_path} | read linevar")
-
-    submodules_to_release_path
-    
-    verbose = Rake.application.options.trace ? 'v' : ''
-    backend.execute("find #{release_path} -name '.git*' | xargs -I {} rm -rf#{verbose} '{}'")
+  def register_hooks
+    after 'git:create_release', 'git:submodules:create_release'
   end
 
-  ##
-  # Adds configured submodules recursively to release
-  # It does so by connecting the bare repo and the work tree using environment variables
-  # The reset creates a temporary index, but does not change the working directory
-  # The temporary index is removed after everything is done
-  def submodules_to_release_path
-    temp_index_file_path = release_path.join("INDEX_#{fetch(:release_timestamp)}")
-    backend.within "../releases/#{fetch(:release_timestamp)}" do
-      backend.with(
-          'GIT_DIR' => repo_path.to_s,
-          'GIT_WORK_TREE' => release_path.to_s,
-          'GIT_INDEX_FILE' => temp_index_file_path.to_s
-      ) do
-        git :reset, '--mixed', fetch(:branch)
-        git :submodule, 'update', '--init', '--depth', 1, '--checkout', '--recursive'
-        verbose = Rake.application.options.trace ? 'v' : ''
-        backend.execute :rm, "-f#{verbose}", temp_index_file_path.to_s
+  def define_tasks
+    namespace :git do
+      namespace :submodules do
+
+        desc "Adds configured submodules recursively to release"
+        # It does so by connecting the bare repo and the work tree using environment variables
+        # The reset creates a temporary index, but does not change the working directory
+        # The temporary index is removed after everything is done
+        task create_release: :'git:update' do
+          temp_index_file_path = release_path.join("TEMP_INDEX_#{fetch(:release_timestamp)}")
+
+          on release_roles :all do
+            with fetch(:git_environmental_variables).merge(
+                'GIT_DIR' => repo_path.to_s,
+                'GIT_WORK_TREE' => release_path.to_s,
+                'GIT_INDEX_FILE' => temp_index_file_path.to_s
+            ) do
+              within release_path do
+                verbose = Rake.application.options.trace ? 'v' : ''
+                quiet = Rake.application.options.trace ? '' : '--quiet'
+
+                execute :git, :reset, '--mixed', quiet, fetch(:branch)
+                execute :git, :submodule, 'update', '--init', '--depth', 1, '--checkout', '--recursive', quiet
+                execute :rm, "-f#{verbose}", temp_index_file_path.to_s
+              end
+            end
+          end
+        end
+
       end
     end
   end


### PR DESCRIPTION
This implements the idea I was talking about in https://github.com/capistrano/capistrano/pull/1823#issuecomment-268547206

`WithSubmodules` is now a `Capistrano::Plugin` and not a subclass of `Capistrano::SCM::Git` anymore. Thus it has to be added as plugin seperately, which would allow other plugins to be added in a similar fashion. See the updated README.

I had to remove your `find ... | rm` part, because it deleted only the wrong stuff. Maybe you could add it in your project on a hook after `git:create_release` if necessary?

What do you think?