### PR TITLE
Fix problem with unreachable ref in submodule

### DIFF
--- a/lib/capistrano/scm/git-with-submodules.rb
+++ b/lib/capistrano/scm/git-with-submodules.rb
@@ -29,7 +29,7 @@ class Capistrano::SCM::Git::WithSubmodules < Capistrano::Plugin
 
                 execute :git, :reset, '--mixed', quiet, fetch(:branch)
                 execute :git, :submodule, 'update', '--init', '--checkout', '--recursive', quiet
-                execute :find, release_path, "-name '.git'", "-printf 'removed %p'", "-delete"
+                execute :find, release_path, "-name '.git'", "-printf 'removed %p\\n'", "-delete"
                 execute :rm, "-f#{verbose}", temp_index_file_path.to_s
               end if test :test, '-f', release_path.join('.gitmodules')
             end

--- a/lib/capistrano/scm/git-with-submodules.rb
+++ b/lib/capistrano/scm/git-with-submodules.rb
@@ -28,7 +28,7 @@ class Capistrano::SCM::Git::WithSubmodules < Capistrano::Plugin
                 quiet = Rake.application.options.trace ? '' : '--quiet'
 
                 execute :git, :reset, '--mixed', quiet, fetch(:branch)
-                execute :git, :submodule, 'update', '--init', '--depth', 1, '--checkout', '--recursive', quiet
+                execute :git, :submodule, 'update', '--init', '--checkout', '--recursive', quiet
                 execute :find, release_path, "-name '.git'", "-printf 'removed %p'", "-delete"
                 execute :rm, "-f#{verbose}", temp_index_file_path.to_s
               end if test :test, '-f', release_path.join('.gitmodules')


### PR DESCRIPTION
If you have a submodule with a ref that is not the current HEAD, it can become unreachable and therefore the deployment fails.
Removing the `--depth 1` option fixes the problem.

I added a linebreak seperating the "Deleted" statements, too, hope thats ok.

Cheers