### PR TITLE
fix find command, use xargs

### DIFF
--- a/lib/capistrano/scm/git-with-submodules.rb
+++ b/lib/capistrano/scm/git-with-submodules.rb
@@ -29,7 +29,7 @@ class Capistrano::SCM::Git::WithSubmodules < Capistrano::Plugin
 
                 execute :git, :reset, '--mixed', quiet, fetch(:branch)
                 execute :git, :submodule, 'update', '--init', '--checkout', '--recursive', quiet
-                execute :find, release_path, "-name '.git'", "-printf 'removed %p\\n'", "-delete"
+                execute :find, release_path, "-name '.git'", "|",  "xargs -I {} rm -rf#{verbose} '{}'"
                 execute :rm, "-f#{verbose}", temp_index_file_path.to_s
               end if test :test, '-f', release_path.join('.gitmodules')
             end


### PR DESCRIPTION
Fix using find utility.

There is no find -printf flag on FreeBSD/OsX system, so it caused error
`find: -printf: unknown primary or operator`