### PR TITLE
add-to-update-remote-fetch

### DIFF
--- a/lib/capistrano/scm/git-with-submodules.rb
+++ b/lib/capistrano/scm/git-with-submodules.rb
@@ -29,7 +29,7 @@ class Capistrano::SCM::Git::WithSubmodules < Capistrano::Plugin
 
                 execute :git, :reset, '--mixed', quiet, fetch(:branch), '--'
                 execute :git, :submodule, 'sync', '--recursive', quiet
-                execute :git, :submodule, 'update', '--init', '--checkout', '--recursive', quiet
+                execute :git, :submodule, 'update', '--init', '--checkout', '--recursive', '--remote',  quiet
                 execute :find, release_path, "-name '.git'", "|",  "xargs -I {} rm -rf#{verbose} '{}'"
                 execute :rm, "-f#{verbose}", temp_index_file_path.to_s
               end if test :test, '-f', release_path.join('.gitmodules')


### PR DESCRIPTION
	- Added remote fetch so that actual latest commit gets fetched from remote

I was having some issues with not getting the latest commit from origin, was getting an earlier commit (I expected that I would also get the HEAD in remote from submodule origins). Somehow even after updating local to the latest commit the commands in ruby give the same

Turns out that according to [SO](https://stackoverflow.com/questions/1030169/easy-way-to-pull-latest-of-all-git-submodules) this is normal, and you have to do extra work to get the submodules updated to the remote version.

I saw the note in the contributing section about adding tests, however I am a Ruby noob and I saw that other PRs don't have tests, so I have not added. If you can add some info about how to mock a git remote then I can try 🙏

I tested the change on my Portfolio website by adding my fork in the Gemfile and it looks like it worked for that implementation